### PR TITLE
Ruby 1.9.2+ compatibility: Fix require statement

### DIFF
--- a/migrate_jira.rake
+++ b/migrate_jira.rake
@@ -1,7 +1,7 @@
 require 'rexml/document'
 require 'active_record'
 require 'yaml'
-require 'config/environment'
+require File.expand_path('../../../config/environment', __FILE__) # Assumes that migrate_jira.rake is in lib/tasks/
 
 
 


### PR DESCRIPTION
Running the rakefile with Ruby 1.9.2 or newer will result in the following failure:

```
rake aborted!
cannot load such file -- config/environment
/apps/redmine-2.2.2/lib/tasks/migrate_jira.rake:4:in `require'
/apps/redmine-2.2.2/lib/tasks/migrate_jira.rake:4:in `<top (required)>'
/apps/redmine-2.2.2/Rakefile:7:in `<top (required)>'
```

The reason is that, for security reasons, the pwd is no longer included in Ruby's `LOAD_PATH`.

By the way, thanks for setting up a Github repo! It's much easier to work with than a Redmine ticket.
